### PR TITLE
[PKG-5560] 1.4.3 initial ❄️ 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dschreij @martinRenou @matthiasdiener
+* @AnacondaRecipes/psubs

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,6 @@ cmake ${CMAKE_ARGS} -D CMAKE_BUILD_TYPE=Release     \
       -D CMAKE_INSTALL_LIBDIR=lib     \
       -D BUILD_SHARED_LIBS=ON         \
       -D BUILD_EXAMPLES=OFF           \
-      $EXTRA_MANPAGES_OPT             \
       $SRC_DIR
 
 make -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,14 +2,6 @@
 
 set -ex
 
-# The pandoc package is required for building the manpages,
-# but it is not available currently for ppc64le.
-
-if [[ $target_platform == linux-ppc64le ]]; then
-    EXTRA_MANPAGES_OPT="-D INSTALL_MANPAGES=off"
-fi
-
-
 cmake ${CMAKE_ARGS} -D CMAKE_BUILD_TYPE=Release     \
       -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D CMAKE_INSTALL_LIBDIR=lib     \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ about:
   summary: Flac audio format
   description: Free Lossless Audio Codec.
   doc_url: https://wiki.xiph.org/
-  dev_url: https://gitlab.xiph.org/xiph/flac
+  dev_url: https://github.com/xiph/flac
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - libiconv 1.16  # [osx]
   run:
     - libogg 1.3.*
-    # Resolves overlinking error.
-    # libiconv is included in libc for Linux and not used on Windows.
     - libiconv  # [osx]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ test:
     - if not exist %LIBRARY_BIN%\\FLAC++.dll exit 1   # [win]
     - if not exist %LIBRARY_LIB%\\FLAC.lib exit 1     # [win]
     - if not exist %LIBRARY_BIN%\\FLAC.dll exit 1     # [win]
+    - flac --version
 
 about:
   home: https://www.xiph.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,9 @@ build:
   number: 0
   run_exports:
     - {{ pin_subpackage('libflac', max_pin='x.x') }}
+  # s390x failing with make error 2.
+  # Skipping since s390x is unnecessary for Snowflake.
+  skip: true  # [s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
 
 about:
   home: https://www.xiph.org/
-  license: BSD-3-Clause AND GFDL-1.2-only AND GPL-2.0-only
+  license: BSD-3-Clause AND GPL-2.0-or-later AND GFDL-1.1-or-later
   license_family: OTHER
   license_file: 
     - COPYING.Xiph

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,9 +45,12 @@ test:
 
 about:
   home: https://www.xiph.org/
-  license: BSD-3-Clause
-  license_family: BSD
-  license_file: COPYING.Xiph
+  license: BSD-3-Clause AND GFDL-1.2-only AND GPL-2.0-only
+  license_family: OTHER
+  license_file: 
+    - COPYING.Xiph
+    - COPYING.FDL
+    - COPYING.GPL
   summary: Flac audio format
   description: Free Lossless Audio Codec.
   doc_url: https://wiki.xiph.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,12 +45,13 @@ test:
 
 about:
   home: https://www.xiph.org/
-  license: BSD-3-Clause AND GPL-2.0-or-later AND GFDL-1.1-or-later
+  license: BSD-3-Clause AND GPL-2.0-or-later AND GFDL-1.1-or-later AND LGPL-2.1-or-later
   license_family: OTHER
   license_file: 
     - COPYING.Xiph
     - COPYING.FDL
     - COPYING.GPL
+    - COPYING.LGPL
   summary: Flac audio format
   description: Free Lossless Audio Codec.
   doc_url: https://wiki.xiph.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
   host:
     - gettext 0.21.0 # [unix]
     - libogg 1.3.5
+    # libiconv is included in libc for Linux and not used on Windows.
+    - libiconv 1.16  # [osx]
   run:
     - libogg 1.3.*
     # Resolves overlinking error.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - make  # [unix]
-    - pandoc  # [not ppc64le]
+    - pandoc
   host:
     - gettext  # [unix]
     - libogg 1.3.*
@@ -38,7 +38,6 @@ test:
     - if not exist %LIBRARY_BIN%\\FLAC++.dll exit 1   # [win]
     - if not exist %LIBRARY_LIB%\\FLAC.lib exit 1     # [win]
     - if not exist %LIBRARY_BIN%\\FLAC.dll exit 1     # [win]
-    - flac --version                                  # [build_platform == target_platform]
 
 about:
   home: https://www.xiph.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,8 @@ requirements:
     - make  # [unix]
     - pandoc
   host:
-    - gettext  # [unix]
-    - libogg 1.3.*
+    - gettext 0.21.0 # [unix]
+    - libogg 1.3.5
   run:
     - libogg 1.3.*
     # Resolves overlinking error.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,9 @@ requirements:
     - libogg 1.3.*
   run:
     - libogg 1.3.*
+    # Resolves overlinking error.
+    # libiconv is included in libc for Linux and not used on Windows.
+    - libiconv  # [osx]
 
 test:
   commands:


### PR DESCRIPTION
libflac 1.4.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5560]
- [Upstream repository](https://github.com/xiph/flac/tree/1.4.3)
- [Upstream changelog/diff](https://github.com/xiph/flac/blob/1.4.3/CHANGELOG.md)

### Explanation of changes:

- Removed sections of recipe and script only relevant to `ppc64le`
- Added `libiconv` to osx to fix an overlinking error. `libiconv` is provided by `libc` on Linux, and unused on Windows
- Updated CODEOWNERS
- The license is identical to BSD-3-clause, despite being described as a "BSD-like" proprietary license in the readme, so I'm leaving it labeled as BSD.


[PKG-5560]: https://anaconda.atlassian.net/browse/PKG-5560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ