### PR TITLE
libflac 1.4.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "flac" %}
-{% set version = "1.4.3" %}
-{% set sha256 = "0a4bb82a30609b606650d538a804a7b40205366ce8fc98871b0ecf3fbb0611ee" %}
+{% set version = "1.5.0" %}
 
 package:
   name: lib{{ name|lower }}
@@ -8,30 +7,28 @@ package:
 
 source:
   url: https://github.com/xiph/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: aea54ed186ad07a34750399cb27fc216a2b62d0ffcd6dc2e3064a3518c3146f8
 
 build:
   number: 0
   run_exports:
     - {{ pin_subpackage('libflac', max_pin='x.x') }}
-  # s390x failing with make error 2.
-  # Skipping since s390x is unnecessary for Snowflake.
-  skip: true  # [s390x]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake
     - make  # [unix]
+    - cmake
     - pandoc
   host:
-    - gettext 0.21.0 # [unix]
-    - libogg 1.3.5
+    - libogg {{ libogg }}
     # libiconv is included in libc for Linux and not used on Windows.
-    - libiconv 1.16  # [osx]
+    - libiconv {{ libiconv }}  # [osx]
+    - gettext {{ gettext }}    # [unix]
   run:
-    - libogg 1.3.*
+    - libogg
     - libiconv  # [osx]
 
 test:
@@ -47,7 +44,7 @@ test:
     - flac --version
 
 about:
-  home: https://www.xiph.org/
+  home: https://www.xiph.org
   license: BSD-3-Clause AND GPL-2.0-or-later AND GFDL-1.1-or-later AND LGPL-2.1-or-later
   license_family: OTHER
   license_file: 
@@ -57,7 +54,7 @@ about:
     - COPYING.LGPL
   summary: Flac audio format
   description: Free Lossless Audio Codec.
-  doc_url: https://wiki.xiph.org/
+  doc_url: https://wiki.xiph.org
   dev_url: https://github.com/xiph/flac
 
 extra:


### PR DESCRIPTION
libflac 1.4.3

**Destination channel:** Defaults

### Links

- [PKG-12263]
- dev_url:        https://github.com/xiph/flac/tree/1.5.0
- conda_forge:    https://github.com/conda-forge/libflac-feedstock

### Explanation of changes:

- new entry to the registry

[PKG-12263]: https://anaconda.atlassian.net/browse/PKG-12263